### PR TITLE
Provide Rational Literal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,3 @@ script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.
 
 git:
   depth: 10
-
-branches:
-  only:
-    - master

--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -351,7 +351,7 @@
     'name': 'constant.numeric.ruby'
     'patterns': [
       {
-        'comment': 'rational literal as 3/2r, 1/1.2r and 1.2r',
+        'comment': 'rational literal as 3/2r, 1/1.2r and 1.2r'
         'match': '''(?x)
           \\b
           (?:
@@ -385,7 +385,7 @@
           )r
           \\b
         '''
-      },
+      }
       {
         'match': '''(?x)
           \\b

--- a/grammars/ruby.cson
+++ b/grammars/ruby.cson
@@ -348,23 +348,63 @@
     'name': 'meta.function.method.without-arguments.ruby'
   }
   {
-    'match': '''(?x)
-      \\b
-      (
-        [1-9](?>_?\\d)*                             # 100_000
-        (\\.(?![^[:space:][:digit:]])(?>_?\\d)*)?   # fractional part
-        ([eE][-+]?\\d(?>_?\\d)*)?                   # 1.23e-4
-        |
-        0
-        (?:
-          [xX]\\h(?>_?\\h)*|
-          [oO]?[0-7](?>_?[0-7])*|
-          [bB][01](?>_?[01])*|
-          [dD]\\d(?>_?\\d)*
-        )                                           # A base indicator can only be used with an integer
-      )\\b
-    '''
     'name': 'constant.numeric.ruby'
+    'patterns': [
+      {
+        'comment': 'rational literal as 3/2r, 1/1.2r and 1.2r',
+        'match': '''(?x)
+          \\b
+          (?:
+            (?:
+              [1-9](?>_?\\d)*                             # 100_000
+              (\\.(?![^[:space:][:digit:]])(?>_?\\d)*)?   # fractional part
+              ([eE][-+]?\\d(?>_?\\d)*)?                   # 1.23e-4
+              |
+              0
+              (?:
+                [xX]\\h(?>_?\\h)*|
+                [oO]?[0-7](?>_?[0-7])*|
+                [bB][01](?>_?[01])*|
+                [dD]\\d(?>_?\\d)*
+              )                                           # A base indicator can only be used with an integer
+            )
+          /
+          )?
+          (?:
+            [1-9](?>_?\\d)*                             # 100_000
+            (\\.(?![^[:space:][:digit:]])(?>_?\\d)*)?   # fractional part
+            ([eE][-+]?\\d(?>_?\\d)*)?                   # 1.23e-4
+            |
+            0
+            (?:
+              [xX]\\h(?>_?\\h)*|
+              [oO]?[0-7](?>_?[0-7])*|
+              [bB][01](?>_?[01])*|
+              [dD]\\d(?>_?\\d)*
+            )                                           # A base indicator can only be used with an integer
+          )r
+          \\b
+        '''
+      },
+      {
+        'match': '''(?x)
+          \\b
+          (
+            [1-9](?>_?\\d)*                             # 100_000
+            (\\.(?![^[:space:][:digit:]])(?>_?\\d)*)?   # fractional part
+            ([eE][-+]?\\d(?>_?\\d)*)?                   # 1.23e-4
+            |
+            0
+            (?:
+              [xX]\\h(?>_?\\h)*|
+              [oO]?[0-7](?>_?[0-7])*|
+              [bB][01](?>_?[01])*|
+              [dD]\\d(?>_?\\d)*
+            )                                           # A base indicator can only be used with an integer
+          )\\b
+        '''
+      }
+    ]
   }
   {
     'begin': ':\''

--- a/spec/ruby-spec.coffee
+++ b/spec/ruby-spec.coffee
@@ -66,6 +66,16 @@ describe "Ruby grammar", ->
     {tokens} = grammar.tokenizeLine('0B00100')
     expect(tokens[0]).toEqual value: '0B00100', scopes: ['source.ruby', 'constant.numeric.ruby']
 
+  it "tokenizes rational numbers", ->
+    {tokens} = grammar.tokenizeLine('3/2r')
+    expect(tokens[0]).toEqual value: '3/2r', scopes: ['source.ruby', 'constant.numeric.ruby']
+
+    {tokens} = grammar.tokenizeLine('100_000/0.1r')
+    expect(tokens[0]).toEqual value: '100_000/0.1r', scopes: ['source.ruby', 'constant.numeric.ruby']
+
+    {tokens} = grammar.tokenizeLine('0.1r')
+    expect(tokens[0]).toEqual value: '0.1r', scopes: ['source.ruby', 'constant.numeric.ruby']
+
   it "tokenizes symbols", ->
     {tokens} = grammar.tokenizeLine(':test')
     expect(tokens[0]).toEqual value: ':', scopes: ['source.ruby', 'constant.other.symbol.ruby', 'punctuation.definition.constant.ruby']


### PR DESCRIPTION
I can't remember anything. Hoever looks addressed at Rational syntax in 2016...

https://github.com/atom/language-ruby/commits/master/grammars/ruby.cson 👀 

Hmm... I'm using VScode in these years. 🤔 